### PR TITLE
API Queries w/bot flag

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -16,6 +16,7 @@ module MediaWiki
     # [options] Hash of options
     #
     # Options:
+    # [:bot] When set to true, executes API queries with the bot parameter (see http://www.mediawiki.org/wiki/API:Edit#Parameters).  Defaults to false.
     # [:ignorewarnings] Log API warnings and invalid page titles, instead throwing MediaWiki::APIError
     # [:limit] Maximum number of results returned per search (see http://www.mediawiki.org/wiki/API:Query_-_Lists#Limits), defaults to the MediaWiki default of 500.
     # [:loglevel] Log level to use, defaults to Logger::WARN.  Set to Logger::DEBUG to dump every request and response to the log.


### PR DESCRIPTION
Added a simple :bot option, that defaults to false if nothing is specified.  When passed as true via the options hash in the initialization method, mediawiki-gateway will add the 'bot' parameter to all requests, signifying that the query was made by a bot.  Fixes Issue #31.
