### PR TITLE
list:Categorymembers

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -281,7 +281,7 @@ module MediaWiki
     # [options] Optional hash of additional options. See http://www.mediawiki.org/wiki/API:Categorymembers
     #
     # Returns array of page titles (empty if no matches)
-    def list_members(category, options = {})
+    def category_members(category, options = {})
       titles = []
       apfrom = nil
       begin


### PR DESCRIPTION
This is a quickfix for Issue #9, eventually you have to fit this into your naming schema.

Essentially this is just an added function "list_members" and widely a copy of the standard "list", just as I said, a quickfix!
