### PR TITLE
modify semantic_query for SMW Core (v1.7) Ask API

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -557,10 +557,21 @@ module MediaWiki
     #
     # Returns result as an HTML string
     def semantic_query(query, params = [])
-      params << "format=list"
-      form_data = { 'action' => 'parse', 'prop' => 'text', 'text' => "{{#ask:#{query}|#{params.join('|')}}}" }
-      xml, dummy = make_api_request(form_data)
-      return xml.elements["parse/text"].text
+			if extensions.include? 'Semantic MediaWiki'
+				smw_version = extensions['Semantic MediaWiki'].to_f
+				if smw_version >= 1.7
+					form_data = { 'action' => 'ask', 'query' => "#{query}|#{params.join('|')}"}	
+					xml, dummy = make_api_request(form_data)
+					return xml
+				else
+					params << "format=list"
+					form_data = { 'action' => 'parse', 'prop' => 'text', 'text' => "{{#ask:#{query}|#{params.join('|')}}}" }
+					xml, dummy = make_api_request(form_data)
+					return xml.elements["parse/text"].text
+				end
+			else
+				raise MediaWiki::Exception.new "Semantic MediaWiki extension not installed."
+			end
     end
 
     # Set groups for a user

--- a/script/semantic_query.rb
+++ b/script/semantic_query.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+#
+# Sample script for querying Semantic MediaWiki data
+#
+
+require './lib/media_wiki'
+
+mw = MediaWiki::Gateway.new(ARGV[0])
+
+params = []
+i = 2
+until i == ARGV.length
+	params << ARGV[i]
+	i += 1
+end
+
+puts mw.semantic_query(ARGV[1], params)


### PR DESCRIPTION
As of Semantic Mediawiki 1.7 semantic queries can be run using the MediaWiki API.  I updated the 'semantic_query' method to take advantage of this, falling back on the previous implementation of 'semantic_query' for unsupported Semantic MediaWiki versions.

[Documentation link](http://semantic-mediawiki.org/wiki/Ask_API)
