### PR TITLE
custom_query interface

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -656,6 +656,32 @@ module MediaWiki
       res
     end
 
+
+    # Make a custom query
+    #
+    # [options] query options
+    #
+    # Returns the REXML::Element object as result
+    #
+    # Example:
+    #   def create_at(pagename)
+    #     res = bot.custom_query(:prop => :revisions,
+    #                            :titles => pagename,
+    #                            :rvprop => :timestamp,
+    #                            :rvdir => :newer,
+    #                            :rvlimit => 1)
+    #     timestr = res.get_elements('*/*/*/rev')[0].attribute('timestamp').to_s
+    #     time.parse(timestr)
+    #   end
+    #
+    def custom_query(options)
+      form_data = {}
+      options.each {|k,v| form_data[k.to_s] = v.to_s }
+      form_data['action'] = 'query'
+      make_api_request(form_data).first.elements['query']
+    end
+
+
     # Make generic request to API
     #
     # [form_data] hash or string of attributes to post


### PR DESCRIPTION
This interfaces is for users to create custom queries which are not provided by MediaWiki::Gateway directly.
