### PR TITLE
POST all requests

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -765,14 +765,8 @@ module MediaWiki
 
     # Execute the HTTP request using either GET or POST as appropriate
     def http_send url, form_data, headers, &block
-      if form_data['action'] == 'query'
-        log.debug("GET: #{form_data.inspect}, #{@cookies.inspect}")
-        headers[:params] = form_data
-        RestClient.get url, headers, &block
-      else
-        log.debug("POST: #{form_data.inspect}, #{@cookies.inspect}")
-        RestClient.post url, form_data, headers, &block
-      end
+			log.debug("POST: #{form_data.inspect}, #{@cookies.inspect}")
+			RestClient.post url, form_data, headers, &block
     end
 
     # Get API XML response


### PR DESCRIPTION
I'm not sure if there was a reason to only send "action=query" API requests with GET.  This limits the amount  we are able to query from a single request, which is problematic for some dependent methods (such as, export).  I don't notice any stipulations in the API docs showing that a GET is required.  

Thanks.
