### PR TITLE
contributions() no longer ignores a user-provided ucstart param

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -379,7 +379,7 @@ module MediaWiki
     # Returns array of hashes containing the "item" attributes defined here: http://www.mediawiki.org/wiki/API:Usercontribs
     def contributions(user, count = nil, options = {})
       result = []
-      ucstart = nil
+      ucstart = options[:ucstart] or nil 
       begin
         limit = [count, @options[:limit]].compact.min
         form_data = options.merge(


### PR DESCRIPTION
contributions() was ignoring a :ucstart param in options, because it was using its own ucstart for iterated querying.  This trivial patch allows a user to specify an initial ucstart.
