### PR TITLE
apfrom cause error

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -265,6 +265,7 @@ module MediaWiki
         form_data = options.merge(
           {'action' => 'query',
           'list' => 'allpages',
+          'apfrom' => apfrom,
           'apprefix' => key,
           'aplimit' => @options[:limit],
           'apnamespace' => namespace})


### PR DESCRIPTION
I am using this library in Chinese wikipedia, but the apfrom causes an error . It works after I remove it. 
