### PR TITLE
Fix dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 pkg
 nbproject
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,15 @@
-# A sample Gemfile
 source "https://rubygems.org"
 
-gemspec
+gem 'rest-client', '>= 1.3.0'
+gem 'activesupport'
 
-# gem "rails"
+group :development do
+  gem 'jeweler'
+  gem 'sham_rack'
+  gem 'rr'
+  gem 'simplecov'
+  gem 'rspec', '~> 1.3'
+  gem 'debugger'
+  gem 'sinatra'
+  gem 'activemodel'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-PATH
-  remote: .
-  specs:
-    mediawiki-gateway (0.5.2)
-      activesupport
-      mediawiki-gateway
-      rest-client (>= 1.3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,9 +52,10 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel
+  activesupport
   debugger
   jeweler
-  mediawiki-gateway!
+  rest-client (>= 1.3.0)
   rr
   rspec (~> 1.3)
   sham_rack

--- a/Rakefile
+++ b/Rakefile
@@ -35,16 +35,6 @@ begin
     gemspec.homepage = "http://github.com/jpatokal/mediawiki-gateway"
     gemspec.authors = ["Jani Patokallio"]
     gemspec.version = MediaWiki::VERSION
-    gemspec.add_dependency 'rest-client', '>= 1.3.0'
-    gemspec.add_dependency 'activesupport'
-    gemspec.add_development_dependency 'jeweler'
-    gemspec.add_development_dependency 'sham_rack'
-    gemspec.add_development_dependency 'rr'
-    gemspec.add_development_dependency 'simplecov'
-    gemspec.add_development_dependency 'rspec', '~> 1.3'
-    gemspec.add_development_dependency 'debugger'
-    gemspec.add_development_dependency 'sinatra'
-    gemspec.add_development_dependency 'activemodel'
   end
 rescue LoadError
   puts "Jeweler not available. Install it with: gem install jeweler"

--- a/mediawiki-gateway.gemspec
+++ b/mediawiki-gateway.gemspec
@@ -9,16 +9,19 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jani Patokallio"]
-  s.date = "2013-07-29"
+  s.date = "2014-01-26"
   s.description = ""
   s.email = "jpatokal@iki.fi"
   s.extra_rdoc_files = [
+    "LICENSE",
     "README"
   ]
   s.files = [
+    ".ruby-version",
     ".rvmrc",
     "Gemfile",
     "Gemfile.lock",
+    "LICENSE",
     "README",
     "Rakefile",
     "config/hosts.yml",
@@ -58,15 +61,6 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mediawiki-gateway>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<sham_rack>, [">= 0"])
-      s.add_development_dependency(%q<rr>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<rspec>, ["~> 1.3"])
-      s.add_development_dependency(%q<debugger>, [">= 0"])
-      s.add_development_dependency(%q<sinatra>, [">= 0"])
-      s.add_development_dependency(%q<activemodel>, [">= 0"])
       s.add_runtime_dependency(%q<rest-client>, [">= 1.3.0"])
       s.add_runtime_dependency(%q<activesupport>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
@@ -78,15 +72,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<sinatra>, [">= 0"])
       s.add_development_dependency(%q<activemodel>, [">= 0"])
     else
-      s.add_dependency(%q<mediawiki-gateway>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<sham_rack>, [">= 0"])
-      s.add_dependency(%q<rr>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<rspec>, ["~> 1.3"])
-      s.add_dependency(%q<debugger>, [">= 0"])
-      s.add_dependency(%q<sinatra>, [">= 0"])
-      s.add_dependency(%q<activemodel>, [">= 0"])
       s.add_dependency(%q<rest-client>, [">= 1.3.0"])
       s.add_dependency(%q<activesupport>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -99,15 +84,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<activemodel>, [">= 0"])
     end
   else
-    s.add_dependency(%q<mediawiki-gateway>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<sham_rack>, [">= 0"])
-    s.add_dependency(%q<rr>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<rspec>, ["~> 1.3"])
-    s.add_dependency(%q<debugger>, [">= 0"])
-    s.add_dependency(%q<sinatra>, [">= 0"])
-    s.add_dependency(%q<activemodel>, [">= 0"])
     s.add_dependency(%q<rest-client>, [">= 1.3.0"])
     s.add_dependency(%q<activesupport>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])


### PR DESCRIPTION
http://rubygems.org/gems/mediawiki-gateway/versions/0.5.2 has many dependency issues: depends on itself, duplicates. It makes impossible to install gem.

Moving deps to the Gemfile fixes such issues.
