### PR TITLE
Allow marking of single edits as bot edits

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -136,7 +136,7 @@ module MediaWiki
     # * [:notminor] Mark this edit as "major" if true
     def create(title, content, options={})
       form_data = {'action' => 'edit', 'title' => title, 'text' => content, 'summary' => (options[:summary] || ""), 'token' => get_token('edit', title)}
-      if @options[:bot]
+      if @options[:bot] or options[:bot]
         form_data['bot'] = '1'
         form_data['assert'] = 'bot'
       end


### PR DESCRIPTION
This lets you do things like:

``` ruby
    require 'media_wiki'
    api = MediaWiki::Gateway.new 'http://mywiki.com/api.php'
    api.login 'Bot account', 'password'
    api.edit('Sandbox', 'This is a bot edit', {:bot => true, :summary => 'bot edit'})
    api.edit('Sandbox', 'This is not a bot edit', {:summary => 'not bot edit'})
```

To do this otherwise, you'd need to keep two separate instances of `MediaWiki::Gateway` around for edits and non-bot edits respectively. This is impractical and annoying, especially when you are writing a bot which needs to leave notifications on user's talk pages (and want these edits to appear in RecentChanges).
