### PR TITLE
Add siteinfo and version

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -668,6 +668,26 @@ module MediaWiki
       )).first
     end
 
+    # Get the wiki's siteinfo as a hash. See http://www.mediawiki.org/wiki/API:Siteinfo.
+    #
+    # [options] Hash of additional options
+    def siteinfo(options = {})
+      res = make_api_request(options.merge(
+        'action' => 'query',
+        'meta'   => 'siteinfo'
+      )).first
+
+      REXML::XPath.first(res, '//query/general')
+        .attributes.each_with_object({}) { |(k, v), h| h[k] = v }
+    end
+
+    # Get the wiki's MediaWiki version.
+    #
+    # [options] Hash of additional options passed to #siteinfo
+    def version(options = {})
+      siteinfo(options).fetch('generator', '').split.last
+    end
+
     # Get a list of all known namespaces
     #
     # [options] Hash of additional options

--- a/spec/fake_media_wiki/query_handling.rb
+++ b/spec/fake_media_wiki/query_handling.rb
@@ -91,9 +91,16 @@ module FakeMediaWiki
     end
     
     def siteinfo
-      siteinfo_type = params[:siprop].to_sym
-      return send(siteinfo_type) if respond_to?(siteinfo_type)
-      halt(404, "Page not found")
+      if siteinfo_type = params[:siprop]
+        return send(siteinfo_type) if respond_to?(siteinfo_type)
+        halt(404, "Page not found")
+      else
+        api_response do |_|
+          _.query do
+            _.general(generator: "MediaWiki #{MediaWiki::VERSION}")
+          end
+        end
+      end
     end
     
     def namespaces

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -719,6 +719,32 @@ describe MediaWiki::Gateway do
 
   end
 
+  describe "#siteinfo" do
+
+    before do
+      $fake_media_wiki.reset
+      @siteinfo = @gateway.siteinfo
+    end
+
+    it "should get the siteinfo" do
+      @siteinfo.should == { 'generator' => "MediaWiki #{MediaWiki::VERSION}" }
+    end
+
+  end
+
+  describe "#version" do
+
+    before do
+      $fake_media_wiki.reset
+      @version = @gateway.version
+    end
+
+    it "should get the version" do
+      @version.should == MediaWiki::VERSION
+    end
+
+  end
+
   describe "#namespaces_by_prefix" do
 
     before do


### PR DESCRIPTION
This exposes `siteinfo` from the [MediaWiki API](http://www.mediawiki.org/wiki/API:Siteinfo) and provides a convenience method `version` to extract the version number from the `generator` element.
