### PR TITLE
Do not continue when enough contributions have been received

### DIFF
--- a/lib/media_wiki/gateway/users.rb
+++ b/lib/media_wiki/gateway/users.rb
@@ -51,6 +51,7 @@ module MediaWiki
         )) { |element|
           result << hash = {}
           element.attributes.each { |key, value| hash[key] = value }
+          break if count and result.size >= count
         }
 
         count ? result.take(count) : result


### PR DESCRIPTION
When a limited number of contributions is requested, Mediawiki now sends a reply with the continue attributes, so the gateway keeps requesting contributions.

Now it stops when the count is reached.
