### PR TITLE
Fix: categorymembers to match new continue rules

### DIFF
--- a/lib/media_wiki/gateway/pages.rb
+++ b/lib/media_wiki/gateway/pages.rb
@@ -274,7 +274,7 @@ module MediaWiki
       def category_members(category, options = {})
         iterate_query('categorymembers', '//cm', 'title', 'cmcontinue', options.merge(
           'cmtitle' => category,
-          'continue' => '' # new format, per https://www.mediawiki.org/wiki/API:Query#Continuing_queries
+          'continue' => '', # new format, per https://www.mediawiki.org/wiki/API:Query#Continuing_queries
           'cmlimit' => @options[:limit]
         ))
       end


### PR DESCRIPTION
categorymembers was not working for me on current Wikimedia servers.  I reported it as issue #81 and this (trivial) patch fixes it.
