### PR TITLE
Change the exception superclass to StandardError

### DIFF
--- a/lib/media_wiki/exception.rb
+++ b/lib/media_wiki/exception.rb
@@ -1,7 +1,7 @@
 module MediaWiki
 
   # General exception occurred within MediaWiki::Gateway, and parent class for MediaWiki::APIError, MediaWiki::Unauthorized.
-  class Exception < ::Exception
+  class Exception < ::StandardError
   end
 
   # Wrapper for errors returned by MediaWiki API.  Possible codes are defined in http://www.mediawiki.org/wiki/API:Errors_and_warnings.


### PR DESCRIPTION
Changed the superclass of MediaWiki::Exception from ::Exception to ::StandardError.

It's best practice in Ruby to rescue StandardError instead of Exception. Exceptions that are not StandardErrors are reserved for things like Interrupts, out of memory errors, and so on. Normal Ruby code is supposed to use StandardErrors.