### PR TITLE
Handle maxlag errors when returned with HTTP 200 and text/xml

### DIFF
--- a/lib/media_wiki.rb
+++ b/lib/media_wiki.rb
@@ -1,4 +1,5 @@
 require_relative 'media_wiki/version'
 require_relative 'media_wiki/exception'
 require_relative 'media_wiki/utils'
+require_relative 'media_wiki/response'
 require_relative 'media_wiki/gateway'

--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -125,12 +125,21 @@ module MediaWiki
     #
     # Returns array of XML document and query continue parameter.
     def make_api_request(form_data, continue_xpath = nil, retry_count = 1)
+      if retry_count >= @options[:retry_count]
+        raise MediaWiki::Exception.new("Retries exceeded: Terminating after #{retry_count - 1} retries")
+      end
+
       form_data.update('format' => 'xml', 'maxlag' => @options[:maxlag])
 
       http_send(@wiki_url, form_data, @headers.merge(cookies: @cookies)) do |response|
-        if response.code == 503 && retry_count < @options[:retry_count]
-          log.warn("503 Service Unavailable: #{response.body}.  Retry in #{@options[:retry_delay]} seconds.")
-          sleep(@options[:retry_delay])
+        if response.code == 503
+          retry_delay = @options[:retry_delay]
+          if response.headers.has_key?(:retry_after)
+            retry_delay = [@options[:retry_delay], response.headers[:retry_after].to_i].max
+          end
+
+          log.warn("503 Service Unavailable: #{response.body}.  Retry in #{retry_delay} seconds.")
+          sleep(retry_delay)
           make_api_request(form_data, continue_xpath, retry_count + 1)
         end
 
@@ -139,7 +148,29 @@ module MediaWiki
           raise MediaWiki::Exception.new("Bad response: #{response}")
         end
 
-        doc = get_response(response.dup)
+        # Parse the XML (raises exception if invalid XML)
+        response = MediaWiki::Response.new(response)
+
+        # Note: Although the documentation suggests that a maxlag error should
+        # return HTTP 503, in practice some wikis (such as en.wikipedia.org)
+        # actually return HTTP 200 with an XML (as opposed to text/plain)
+        # response.
+        if response.has_error? && response.error_code == 'maxlag'
+          retry_delay = @options[:retry_delay]
+          if response.headers.has_key?(:retry_after)
+            retry_delay = [@options[:retry_delay], response.headers[:retry_after].to_i].max
+          end
+
+          log.warn("maxlag exceeded: #{response.body}.  Retry in #{retry_delay} seconds.")
+          sleep(retry_delay)
+          make_api_request(form_data, continue_xpath, retry_count + 1)
+        end
+
+        # Handle any errors or warnings that were included in the response
+        check_response(response)
+
+        doc = response.doc
+        log.debug("RES: #{doc}")
 
         # login and createaccount actions require a second request with a token received on the first request
         if %w[login createaccount].include?(action = form_data['action'])
@@ -196,32 +227,21 @@ module MediaWiki
 
     end
 
-    # Get API XML response
-    # If there are errors or warnings, raise APIError
-    # Otherwise return XML root
-    def get_response(res)
-      begin
-        res = res.force_encoding('UTF-8') if res.respond_to?(:force_encoding)
-        doc = REXML::Document.new(res).root
-      rescue REXML::ParseException
-        raise MediaWiki::Exception.new('Response is not XML.  Are you sure you are pointing to api.php?')
-      end
-
-      log.debug("RES: #{doc}")
-
-      unless %w[api mediawiki].include?(doc.name)
+    # 1. Raises exception if repsonse is not a valid MediaWiki XML response
+    # 2. Raises exception if response contains errors
+    # 3. Prints warnings
+    def check_response(res)
+      unless %w[api mediawiki].include?(res.doc.name)
         raise MediaWiki::Exception.new("Response does not contain Mediawiki API XML: #{res}")
       end
 
-      if error = doc.elements['error']
-        raise APIError.new(*error.attributes.values_at(*%w[code info]))
+      if res.has_error?
+        raise APIError.new(*res.error.attributes.values_at(*%w[code info]))
       end
 
-      if warnings = doc.elements['warnings']
-        warning("API warning: #{warnings.children.map(&:text).join(', ')}")
+      if res.has_warnings?
+        warning("API warning: #{res.warnings.children.map(&:text).join(', ')}")
       end
-
-      doc
     end
 
     def validate_options(options, valid_options)

--- a/lib/media_wiki/response.rb
+++ b/lib/media_wiki/response.rb
@@ -1,0 +1,46 @@
+require 'delegate'
+require 'rexml/document'
+
+module MediaWiki
+
+  class Response < ::SimpleDelegator
+    attr_reader :doc
+
+    def initialize(response)
+      super(response)
+
+      self.force_encoding('UTF-8') if self.respond_to?(:force_encoding)
+
+      begin
+        @doc = REXML::Document.new(response).root
+      rescue REXML::ParseException
+        raise MediaWiki::Exception.new('Response is not XML.  Are you sure you are pointing to api.php?')
+      end
+    end
+
+    def has_error?
+      ! self.error.nil?
+    end
+
+    def error
+      @doc.elements['error']
+    end
+
+    def error_code
+      self.error.attributes['code']
+    end
+
+    def error_info
+      self.error.attributes['info']
+    end
+
+    def has_warnings?
+      ! self.warnings.nil?
+    end
+
+    def warnings
+      @doc.elements['warnings']
+    end
+  end
+
+end


### PR DESCRIPTION
This issue has long been outstanding, e.g., https://github.com/jpatokal/mediawiki-gateway/issues/22

Anyway, I wrote some tests to test this. However, I wasn't able to get the live gateway working locally (docker was hanging; I don't know whether it was downloading something?), so that wasn't tested.