### PR TITLE
Allow page edit to not overwrite existing page

### DIFF
--- a/lib/media_wiki/gateway/pages.rb
+++ b/lib/media_wiki/gateway/pages.rb
@@ -113,9 +113,25 @@ module MediaWiki
 
       # Edit page
       #
-      # Same options as create, but always overwrites existing pages (and creates them if they don't exist already).
+      # Same options as create
       def edit(title, content, options = {})
-        create(title, content, { overwrite: true }.merge(options))
+        form_data = options.merge(
+          'action'  => 'edit',
+          'title'   => title,
+          'text'    => content,
+          'summary' => options[:summary] || '',
+          'token'   => get_token('edit', title)
+        )
+
+        if @options[:bot] || options[:bot]
+          form_data.update('bot' => '1', 'assert' => 'bot')
+        end
+
+        form_data['minor']    = '1' if options[:minor]
+        form_data['notminor'] = '1' if options[:minor] == false || options[:notminor]
+        form_data['section']  = options[:section].to_s if options[:section]
+
+        send_request(form_data)
       end
 
       # Protect/unprotect a page


### PR DESCRIPTION
Setup `Pages#edit` to allow modifying pages and not overwriting them completely. This is very useful when you only want to edit a particular section. I think this is backwards compatible, only difference being now there's the potential for an edit conflict.