### PR TITLE
use new meta method to fetch token

### DIFF
--- a/lib/media_wiki/gateway.rb
+++ b/lib/media_wiki/gateway.rb
@@ -68,15 +68,14 @@ module MediaWiki
     private
 
     # Fetch token (type 'delete', 'edit', 'email', 'import', 'move', 'protect')
+    # page_titles kept for backwards compatibility when an individual token was needed for each page
     def get_token(type, page_titles)
       res = send_request(
         'action'  => 'query',
-        'prop'    => 'info',
-        'intoken' => type,
-        'titles'  => page_titles
+        'meta'    => 'tokens'
       )
 
-      unless token = res.elements['query/pages/page'].attributes[type + 'token']
+      unless token = res.elements['query/tokens'].attributes["csrftoken"]
         raise Unauthorized.new "User is not permitted to perform this operation: #{type}"
       end
 


### PR DESCRIPTION
Per [API:Tokens](https://www.mediawiki.org/wiki/API:Tokens), with MediaWiki v1.24 or later we should be fetching a token via `action=query&meta=tokens`, disregarding the page we are actioning on. This of course means we are dropping support for earlier MediaWiki versions. Maybe there's a way to check which version they are using?