### PR TITLE
Allow forcing of bot flag to false

### DIFF
--- a/lib/media_wiki/gateway/pages.rb
+++ b/lib/media_wiki/gateway/pages.rb
@@ -99,7 +99,7 @@ module MediaWiki
           'token'   => get_token('edit', title)
         }
 
-        if @options[:bot] || options[:bot]
+        if options[:bot] != false && (@options[:bot] || options[:bot])
           form_data.update('bot' => '1', 'assert' => 'bot')
         end
 


### PR DESCRIPTION
The default settings for recent changes and watchlists usually hides bot edits, however sometimes bots may want to show up in these feeds but still retain the bot flag for other API operations (so as to not hit throttle limits, etc). Here we check if `options[:bot] != false` meaning it was explicitly passed in as false, as opposed to `nil`
